### PR TITLE
Håndtere at sif-innsyn kan sende inn beskjed med link som null

### DIFF
--- a/src/main/kotlin/no/nav/sifinnsynapi/konsumenter/K9BeskjedKonsument.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/konsumenter/K9BeskjedKonsument.kt
@@ -65,14 +65,14 @@ private fun K9Beskjed.somNøkkel(systembruker: String): Nokkel {
 }
 
 private fun K9Beskjed.somBeskjed(): Beskjed {
-    val link = link ?: ""
+    val linkUtenNull = link ?: ""
     return Beskjed(
             System.currentTimeMillis(),
             Instant.now().plus(dagerSynlig, ChronoUnit.DAYS).toEpochMilli(),
             søkerFødselsnummer,
             grupperingsId,
             tekst,
-            link,
+            linkUtenNull,
             4
     )
 }

--- a/src/main/kotlin/no/nav/sifinnsynapi/konsumenter/K9BeskjedKonsument.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/konsumenter/K9BeskjedKonsument.kt
@@ -65,6 +65,7 @@ private fun K9Beskjed.somNøkkel(systembruker: String): Nokkel {
 }
 
 private fun K9Beskjed.somBeskjed(): Beskjed {
+    val link = link ?: ""
     return Beskjed(
             System.currentTimeMillis(),
             Instant.now().plus(dagerSynlig, ChronoUnit.DAYS).toEpochMilli(),

--- a/src/test/kotlin/no/nav/sifinnsynapi/konsumenter/InnsynHendelseKonsumentIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/konsumenter/InnsynHendelseKonsumentIntegrasjonsTest.kt
@@ -93,5 +93,33 @@ class InnsynHendelseKonsumentIntegrasjonsTest {
             assertThat(lesMelding).isNotEmpty()
         }
     }
+
+    @Test
+    fun `Skal håndtere at link i K9Beskjed er satt til null, gjør den om til ""`() {
+
+        // legg på 1 hendelse om mottatt søknad om pleiepenger sykt barn med link = null...
+        val melding = K9Beskjed(
+                metadata = Metadata(
+                        version = 1,
+                        correlationId = UUID.randomUUID().toString(),
+                        requestId = UUID.randomUUID().toString()
+                ),
+                grupperingsId = "pleiepenger-sykt-barn",
+                eventId = UUID.randomUUID().toString(),
+                søkerFødselsnummer = "12345678910",
+                tekst = "Vi har mottatt din søknad om pleiepenger - sykt barn. Klikk undr for mer info.",
+                link = null,
+                dagerSynlig = 7
+        )
+        producer.leggPåTopic(melding, K9_DITTNAV_VARSEL_BESKJED, mapper)
+
+        // forvent at mottatt hendelse konsumeres og persisteres, samt at gitt restkall gitt forventet resultat.
+        await.atMost(60, TimeUnit.SECONDS).untilAsserted {
+
+            val lesMelding = dittNavConsumer.lesMelding(melding.eventId)
+            log.info("----> dittnav melding: {}", lesMelding)
+            assertThat(lesMelding).isNotEmpty()
+        }
+    }
 }
 

--- a/src/test/kotlin/no/nav/sifinnsynapi/konsumenter/InnsynHendelseKonsumentIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/konsumenter/InnsynHendelseKonsumentIntegrasjonsTest.kt
@@ -97,17 +97,17 @@ class InnsynHendelseKonsumentIntegrasjonsTest {
     @Test
     fun `Skal håndtere at link i K9Beskjed er satt til null, gjør den om til ""`() {
 
-        // legg på 1 hendelse om mottatt søknad om pleiepenger sykt barn med link = null...
+        // legg på 1 hendelse om mottatt søknad om midlertidig alene med link = null...
         val melding = K9Beskjed(
                 metadata = Metadata(
                         version = 1,
                         correlationId = UUID.randomUUID().toString(),
                         requestId = UUID.randomUUID().toString()
                 ),
-                grupperingsId = "pleiepenger-sykt-barn",
+                grupperingsId = "omp-midlertidig-alene",
                 eventId = UUID.randomUUID().toString(),
                 søkerFødselsnummer = "12345678910",
-                tekst = "Vi har mottatt din søknad om pleiepenger - sykt barn. Klikk undr for mer info.",
+                tekst = "Vi har mottatt omsorgspengesøknad fra deg om å bli regnet som alene om omsorgen for barn.",
                 link = null,
                 dagerSynlig = 7
         )


### PR DESCRIPTION
I de ytelsene hvor vi ikke har en link til innsyn så settes det til null i sif-innsyn. K9-dittnav-varsel må håndtere dette og sette link til "" dersom den er null.