### PR TITLE
Setter requestId til å være nullable og default null.

### DIFF
--- a/src/main/kotlin/no/nav/sifinnsynapi/konsumenter/K9BeskjedKonsument.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/konsumenter/K9BeskjedKonsument.kt
@@ -52,7 +52,7 @@ data class K9Beskjed(
 data class Metadata @JsonCreator constructor(
         @JsonProperty("version") val version : Int,
         @JsonProperty("correlationId") val correlationId : String,
-        @JsonProperty("requestId") val requestId : String
+        @JsonProperty("requestId") val requestId : String? = null
 )
 
 fun K9Beskjed.somJson(mapper: ObjectMapper) = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(this)


### PR DESCRIPTION
Når andre applikasjoner blir oppdatert til nyeste dusseldorf-ktor blir ikke requestId sendt med videre.