### PR TITLE
Overstyrer log4j versjon med sårbarhet.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ configurations {
 }
 val springfoxVersion by extra("2.9.2")
 val confluentVersion by extra("5.5.0")
+ext["log4j2.version"] = "2.15.0" // TODO: 13/12/2021 kan fjernes når spring boot oppgraderes til  v2.5.8 eller v2.6.2
 
 val avroVersion by extra("1.9.2")
 val brukernotifikasjonVersion by extra("1.2021.01.18-11.12-b9c8c40b98d1")


### PR DESCRIPTION
Info om sårbarhet: https://nvd.nist.gov/vuln/detail/CVE-2021-44228
Info fra Spring Boot: https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot