### PR TITLE
Oppdaterer log4j2 til 2.16.0.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,6 @@ configurations {
 }
 val springfoxVersion by extra("2.9.2")
 val confluentVersion by extra("5.5.0")
-ext["log4j2.version"] = "2.15.0" // TODO: 13/12/2021 kan fjernes når spring boot oppgraderes til  v2.5.8 eller v2.6.2
 val avroVersion by extra("1.9.2")
 val brukernotifikasjonVersion by extra("1.2021.01.18-11.12-b9c8c40b98d1")
 val logstashLogbackEncoderVersion by extra("6.3")
@@ -30,6 +29,8 @@ val awaitilityKotlinVersion by extra("4.1.0")
 val assertkJvmVersion by extra("0.24")
 val springMockkVersion by extra("3.0.1")
 val mockkVersion by extra("1.12.0")
+
+ext["log4j2.version"] = "2.16.0" // TODO: 13/12/2021 kan fjernes når spring boot oppgraderes til  v2.5.8 eller v2.6.2
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Håndterer potensiell DoS angrep.
Se her for mer info: https://www.lunasec.io/docs/blog/log4j-zero-day-update-on-cve-2021-45046/#notes-on-the-denial-of-service-in-2150