### PR TITLE
Migrerer fra AVRO til JSON topic for varsler.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ java {
 val confluentVersion by extra("7.6.0")
 val avroVersion by extra("1.11.4")
 val brukernotifikasjonVersion by extra("v2.5.1")
+val tmsVarselVersjon by extra("2.1.1")
 val logstashLogbackEncoderVersion by extra("7.4")
 val retryVersion by extra("2.0.5")
 val jsonVersion by extra("20240303")
@@ -41,6 +42,11 @@ repositories {
     maven {
         name = "github-package-registry-navikt"
         url = uri("https://maven.pkg.github.com/navikt/maven-release")
+    }
+
+    maven {
+        name = "github-package-registry-mirror-navikt"
+        url = uri("https://github-package-registry-mirror.gc.nav.no/cached/maven-release")
     }
 
     maven {
@@ -60,6 +66,7 @@ dependencies {
     // NAV
     implementation("com.github.navikt:brukernotifikasjon-schemas:$brukernotifikasjonVersion")
     implementation("com.github.navikt:tms-mikrofrontend-selector:20231005112556-1c554d9")
+    implementation("no.nav.tms.varsel:kotlin-builder:$tmsVarselVersjon")
 
     // Spring Boot
     implementation("org.springframework.boot:spring-boot-starter-actuator")

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/Topics.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/Topics.kt
@@ -2,11 +2,15 @@ package no.nav.sifinnsynapi.config
 
 object Topics {
     const val K9_DITTNAV_VARSEL_BESKJED = "dusseldorf.privat-k9-dittnav-varsel-beskjed"
-    const val DITT_NAV_BESKJED = "min-side.aapen-brukernotifikasjon-beskjed-v1"
+    const val DITT_NAV_VARSEL = "min-side.aapen-brukervarsel-v1"
 
     const val K9_DITTNAV_VARSEL_UTKAST = "dusseldorf.privat-k9-dittnav-varsel-utkast"
     const val DITT_NAV_UTKAST = "min-side.aapen-utkast-v1"
 
     const val K9_DITTNAV_VARSEL_MICROFRONTEND = "dusseldorf.privat-k9-dittnav-varsel-microfrontend"
     const val DITT_NAV_MICROFRONTEND = "min-side.aapen-microfrontend-v1"
+
+    // Legacy AVRO topic - vil fjernes etter migrering
+    @Deprecated("Bruk DITT_NAV_VARSEL istedet")
+    const val DITT_NAV_BESKJED = "min-side.aapen-brukernotifikasjon-beskjed-v1"
 }

--- a/src/main/kotlin/no/nav/sifinnsynapi/dittnav/DittnavService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/dittnav/DittnavService.kt
@@ -3,6 +3,7 @@ package no.nav.sifinnsynapi.dittnav
 import no.nav.brukernotifikasjon.schemas.input.BeskjedInput
 import no.nav.brukernotifikasjon.schemas.input.NokkelInput
 import no.nav.sifinnsynapi.config.Topics.DITT_NAV_BESKJED
+import no.nav.sifinnsynapi.config.Topics.DITT_NAV_VARSEL
 import no.nav.sifinnsynapi.config.Topics.DITT_NAV_MICROFRONTEND
 import no.nav.sifinnsynapi.config.Topics.DITT_NAV_UTKAST
 import org.apache.kafka.clients.producer.ProducerRecord
@@ -18,6 +19,7 @@ class DittnavService(
 ) {
     val logger = LoggerFactory.getLogger(DittnavService::class.java)
 
+    @Deprecated("Bruk sendVarsel istedet")
     fun sendBeskjed(nøkkel: NokkelInput, beskjed: BeskjedInput) {
         beskjedKafkaTemplate.send(ProducerRecord(DITT_NAV_BESKJED, nøkkel, beskjed))
             .exceptionally { ex: Throwable ->
@@ -25,6 +27,16 @@ class DittnavService(
                 throw ex
             }.thenAccept {
                 logger.info("Beskjed sendt til ${DITT_NAV_BESKJED} med eventId ${nøkkel.getEventId()}")
+            }
+    }
+
+    fun sendVarsel(varselId: String, varselJson: String) {
+        kafkaTemplate.send(ProducerRecord(DITT_NAV_VARSEL, varselId, varselJson))
+            .exceptionally { ex: Throwable ->
+                logger.warn("Kunne ikke sende varsel {} til {}", varselId, DITT_NAV_VARSEL, ex)
+                throw ex
+            }.thenAccept {
+                logger.info("Varsel sendt til $DITT_NAV_VARSEL med varselId $varselId")
             }
     }
 


### PR DESCRIPTION
## Bakgrunn
Avro brukes ikke lenger til å validere schema. Varsel-eventer sendes nå som JSON-strenger, med varsel-id som nøkkel.
Produsenter forholder seg kun til ett topic for både opprettelse og inaktivering av varsler.
Tidligere fantes det fire meldingstyper (beskjed, oppgave, innboks, done). Disse er nå slått sammen til to objekter: opprett og inaktiver. Varseltypen angis i opprett-eventet.

Migreringsguide: https://navikt.github.io/tms-dokumentasjon/varsler/migrere 

## Løsning
- Legger til støtte for publisering av varsel på nytt format.
- Publiserer både på gammel og nytt format i migreringsfasen.
- Markerer gammelt avro oppsett som utgått.

## Skjermbilde
<img width="634" height="515" alt="image" src="https://github.com/user-attachments/assets/df37e547-ba7c-4583-8844-d5bf0c53539b" />

