### PR TITLE
Rydder bort AVRO og gammel beskjed oppsett.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,9 +24,6 @@ java {
     targetCompatibility = JavaVersion.VERSION_21
 }
 
-val confluentVersion by extra("7.6.0")
-val avroVersion by extra("1.11.4")
-val brukernotifikasjonVersion by extra("v2.5.1")
 val tmsVarselVersjon by extra("2.1.1")
 val logstashLogbackEncoderVersion by extra("7.4")
 val retryVersion by extra("2.0.5")
@@ -64,7 +61,6 @@ dependencies {
     }
 
     // NAV
-    implementation("com.github.navikt:brukernotifikasjon-schemas:$brukernotifikasjonVersion")
     implementation("com.github.navikt:tms-mikrofrontend-selector:20231005112556-1c554d9")
     implementation("no.nav.tms.varsel:kotlin-builder:$tmsVarselVersjon")
 
@@ -96,9 +92,6 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
 
     //Kafka
-    implementation("org.apache.avro:avro:$avroVersion")
-    implementation("io.confluent:kafka-connect-avro-converter:$confluentVersion")
-    implementation("io.confluent:kafka-avro-serializer:$confluentVersion")
     implementation("org.springframework.kafka:spring-kafka")
     constraints {
         implementation("org.scala-lang:scala-library") {

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/CommonKafkaConfig.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/CommonKafkaConfig.kt
@@ -1,7 +1,6 @@
 package no.nav.sifinnsynapi.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
 import no.nav.sifinnsynapi.util.Constants
 import no.nav.sifinnsynapi.util.MDCUtil
 import org.apache.kafka.clients.CommonClientConfigs
@@ -57,21 +56,6 @@ class CommonKafkaConfig {
                     ConsumerConfig.ISOLATION_LEVEL_CONFIG to consumerProps.isolationLevel,
                     ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to consumerProps.keyDeserializer,
                     ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to consumerProps.valueDeserializer
-                ) + commonConfig(kafkaConfigProps)
-            )
-        }
-
-        fun <K, V> avroProducerFactory(kafkaConfigProps: KafkaConfigProperties): ProducerFactory<K, V> {
-            val producerProps = kafkaConfigProps.producer
-            return DefaultKafkaProducerFactory(
-                mutableMapOf<String, Any>(
-                    ProducerConfig.CLIENT_ID_CONFIG to producerProps.clientId,
-                    ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG to producerProps.keySerializer,
-                    ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to producerProps.valueSerializer,
-                    ProducerConfig.RETRIES_CONFIG to producerProps.retries,
-                    KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG to producerProps.schemaRegistryUrl,
-                    KafkaAvroDeserializerConfig.BASIC_AUTH_CREDENTIALS_SOURCE to "USER_INFO",
-                    KafkaAvroDeserializerConfig.USER_INFO_CONFIG to "${producerProps.schemaRegistryUser}:${producerProps.schemaRegistryPassword}"
                 ) + commonConfig(kafkaConfigProps)
             )
         }

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/KafkaConfig.kt
@@ -1,9 +1,6 @@
 package no.nav.sifinnsynapi.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import no.nav.brukernotifikasjon.schemas.input.BeskjedInput
-import no.nav.brukernotifikasjon.schemas.input.NokkelInput
-import no.nav.sifinnsynapi.config.CommonKafkaConfig.Companion.avroProducerFactory
 import no.nav.sifinnsynapi.config.CommonKafkaConfig.Companion.configureConcurrentKafkaListenerContainerFactory
 import no.nav.sifinnsynapi.config.CommonKafkaConfig.Companion.consumerFactory
 import no.nav.sifinnsynapi.config.CommonKafkaConfig.Companion.stringProducerFactory
@@ -35,25 +32,17 @@ class KafkaConfig(
     fun producerFactory(): ProducerFactory<String, String> = stringProducerFactory(kafkaClusterProperties.aiven)
 
     @Bean
-    fun beskjedProducerFactory(): ProducerFactory<NokkelInput, BeskjedInput> =
-        avroProducerFactory(kafkaClusterProperties.aiven)
-
-    @Bean
-    fun beskjedKafkaTemplate(beskjedProducerFactory: ProducerFactory<NokkelInput, BeskjedInput>): KafkaTemplate<NokkelInput, BeskjedInput> =
-        CommonKafkaConfig.kafkaTemplate(beskjedProducerFactory)
-
-    @Bean
     fun kafkaTemplate(producerFactory: ProducerFactory<String, String>): KafkaTemplate<String, String> =
         CommonKafkaConfig.kafkaTemplate(producerFactory)
 
     @Bean
     fun beskjedKafkaJsonListenerContainerFactory(
         consumerFactory: ConsumerFactory<String, String>,
-        beskjedKafkaTemplate: KafkaTemplate<NokkelInput, BeskjedInput>,
+        kafkaTemplate: KafkaTemplate<String, String>,
     ): ConcurrentKafkaListenerContainerFactory<String, String> =
         configureConcurrentKafkaListenerContainerFactory<K9Beskjed>(
             consumerFactory = consumerFactory,
-            kafkaTemplate = beskjedKafkaTemplate,
+            kafkaTemplate = kafkaTemplate,
             retryInterval = kafkaClusterProperties.aiven.consumer.retryInterval,
             objectMapper = objectMapper,
             logger = logger,

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/KafkaConfigProperties.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/KafkaConfigProperties.kt
@@ -27,12 +27,7 @@ data class KafkaConsumerProperties(
 
 data class KafkaProducerProperties(
     val clientId: String,
-    val keySerializer: String,
-    val valueSerializer: String,
     val retries: Int,
-    val schemaRegistryUrl: String,
-    val schemaRegistryUser: String,
-    val schemaRegistryPassword: String,
 )
 
 data class KafkaProperties(

--- a/src/main/kotlin/no/nav/sifinnsynapi/config/Topics.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/config/Topics.kt
@@ -9,8 +9,4 @@ object Topics {
 
     const val K9_DITTNAV_VARSEL_MICROFRONTEND = "dusseldorf.privat-k9-dittnav-varsel-microfrontend"
     const val DITT_NAV_MICROFRONTEND = "min-side.aapen-microfrontend-v1"
-
-    // Legacy AVRO topic - vil fjernes etter migrering
-    @Deprecated("Bruk DITT_NAV_VARSEL istedet")
-    const val DITT_NAV_BESKJED = "min-side.aapen-brukernotifikasjon-beskjed-v1"
 }

--- a/src/main/kotlin/no/nav/sifinnsynapi/dittnav/DittnavService.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/dittnav/DittnavService.kt
@@ -1,11 +1,8 @@
 package no.nav.sifinnsynapi.dittnav
 
-import no.nav.brukernotifikasjon.schemas.input.BeskjedInput
-import no.nav.brukernotifikasjon.schemas.input.NokkelInput
-import no.nav.sifinnsynapi.config.Topics.DITT_NAV_BESKJED
-import no.nav.sifinnsynapi.config.Topics.DITT_NAV_VARSEL
 import no.nav.sifinnsynapi.config.Topics.DITT_NAV_MICROFRONTEND
 import no.nav.sifinnsynapi.config.Topics.DITT_NAV_UTKAST
+import no.nav.sifinnsynapi.config.Topics.DITT_NAV_VARSEL
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.json.JSONObject
 import org.slf4j.LoggerFactory
@@ -14,21 +11,9 @@ import org.springframework.stereotype.Service
 
 @Service
 class DittnavService(
-    private val beskjedKafkaTemplate: KafkaTemplate<NokkelInput, BeskjedInput>,
     private val kafkaTemplate: KafkaTemplate<String, String>,
 ) {
     val logger = LoggerFactory.getLogger(DittnavService::class.java)
-
-    @Deprecated("Bruk sendVarsel istedet")
-    fun sendBeskjed(nøkkel: NokkelInput, beskjed: BeskjedInput) {
-        beskjedKafkaTemplate.send(ProducerRecord(DITT_NAV_BESKJED, nøkkel, beskjed))
-            .exceptionally { ex: Throwable ->
-                logger.warn("Kunne ikke sende melding {} på {}", nøkkel.getEventId(), DITT_NAV_BESKJED, ex)
-                throw ex
-            }.thenAccept {
-                logger.info("Beskjed sendt til ${DITT_NAV_BESKJED} med eventId ${nøkkel.getEventId()}")
-            }
-    }
 
     fun sendVarsel(varselId: String, varselJson: String) {
         kafkaTemplate.send(ProducerRecord(DITT_NAV_VARSEL, varselId, varselJson))
@@ -41,7 +26,7 @@ class DittnavService(
     }
 
     fun sendUtkast(utkastId: String, utkast: String) {
-        kafkaTemplate.send(ProducerRecord(DITT_NAV_UTKAST, utkastId,  utkast))
+        kafkaTemplate.send(ProducerRecord(DITT_NAV_UTKAST, utkastId, utkast))
             .exceptionally { ex: Throwable ->
                 logger.warn("Kunne ikke sende utkast til {}", DITT_NAV_UTKAST, ex)
                 throw ex
@@ -53,7 +38,7 @@ class DittnavService(
     }
 
     fun toggleMicrofrontend(mikrofrontendId: String, mikrofrontend: String) {
-        kafkaTemplate.send(ProducerRecord(DITT_NAV_MICROFRONTEND, mikrofrontendId,  mikrofrontend))
+        kafkaTemplate.send(ProducerRecord(DITT_NAV_MICROFRONTEND, mikrofrontendId, mikrofrontend))
             .exceptionally { ex: Throwable ->
                 logger.warn("Kunne ikke sende microfrontend event til {}", DITT_NAV_MICROFRONTEND, ex)
                 throw ex

--- a/src/main/kotlin/no/nav/sifinnsynapi/konsumenter/K9Beskjed.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/konsumenter/K9Beskjed.kt
@@ -3,20 +3,13 @@ package no.nav.sifinnsynapi.konsumenter
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
-import no.nav.brukernotifikasjon.schemas.builders.BeskjedInputBuilder
-import no.nav.brukernotifikasjon.schemas.builders.NokkelInputBuilder
-import no.nav.brukernotifikasjon.schemas.input.BeskjedInput
-import no.nav.brukernotifikasjon.schemas.input.NokkelInput
 import no.nav.tms.varsel.action.Produsent
-import no.nav.tms.varsel.builder.VarselActionBuilder
-import no.nav.tms.varsel.action.Varseltype
 import no.nav.tms.varsel.action.Sensitivitet
 import no.nav.tms.varsel.action.Tekst
-import java.net.URL
-import java.time.LocalDateTime
-import java.time.ZoneOffset.UTC
-import java.time.ZonedDateTime
+import no.nav.tms.varsel.action.Varseltype
+import no.nav.tms.varsel.builder.VarselActionBuilder
 import java.time.ZoneId
+import java.time.ZonedDateTime
 
 data class K9Beskjed(
     val metadata: Metadata,
@@ -72,28 +65,6 @@ data class Metadata @JsonCreator constructor(
 )
 
 fun <T> T.somJson(mapper: ObjectMapper) = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(this)
-
-fun K9Beskjed.somNøkkel(): NokkelInput {
-    return NokkelInputBuilder()
-        .withAppnavn("k9-dittnav-varsel")
-        .withNamespace("dusseldorf")
-        .withFodselsnummer(søkerFødselsnummer)
-        .withGrupperingsId(grupperingsId)
-        .withEventId(eventId)
-        .build()
-}
-
-fun K9Beskjed.somBeskjed(): BeskjedInput {
-    val builder = BeskjedInputBuilder()
-        .withEksternVarsling(false)
-        .withSikkerhetsnivaa(4)
-        .withSynligFremTil(LocalDateTime.now().plusDays(dagerSynlig))
-        .withTekst(tekst)
-        .withTidspunkt(LocalDateTime.now(UTC))
-
-    if (link != null) builder.withLink(URL(link))
-    return builder.build()
-}
 
 fun K9Beskjed.somVarselOpprett(): String {
     return VarselActionBuilder.opprett {

--- a/src/main/kotlin/no/nav/sifinnsynapi/konsumenter/Konsument.kt
+++ b/src/main/kotlin/no/nav/sifinnsynapi/konsumenter/Konsument.kt
@@ -32,12 +32,8 @@ class Konsument(
             melding
         ) else logger.info("Mottok K9Beskjed med eventID: {}, event: :{}", melding.eventId, melding)
 
-        // Ved migrering: send både til legacy AVRO topic og ny JSON topic.
         try {
-            // Legacy AVRO format
-            dittnavService.sendBeskjed(melding.somNøkkel(), melding.somBeskjed())
 
-            // Ny JSON format
             dittnavService.sendVarsel(melding.eventId, melding.somVarselOpprett())
 
             logger.info("Beskjed sendt til både legacy og nytt topic for eventId: {}", melding.eventId)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,9 +24,4 @@ kafka:
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
     producer:
       client-id: ${HOSTNAME}
-      key-serializer: io.confluent.kafka.serializers.KafkaAvroSerializer
-      value-serializer: io.confluent.kafka.serializers.KafkaAvroSerializer
       retries: 3
-      schemaRegistryUrl: ${KAFKA_SCHEMA_REGISTRY}
-      schemaRegistryUser: ${KAFKA_SCHEMA_REGISTRY_USER}
-      schemaRegistryPassword: ${KAFKA_SCHEMA_REGISTRY_PASSWORD}

--- a/src/test/kotlin/no/nav/sifinnsynapi/utils/KafkaUtils.kt
+++ b/src/test/kotlin/no/nav/sifinnsynapi/utils/KafkaUtils.kt
@@ -1,8 +1,6 @@
 package no.nav.sifinnsynapi.utils
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig
-import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
 import no.nav.sifinnsynapi.konsumenter.somJson
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerConfig
@@ -30,20 +28,6 @@ fun <T> Producer<String, Any>.leggPåTopic(data: T, topic: String, mapper: Objec
     }
     this.send(ProducerRecord(topic, data.somJson(mapper)))
     this.flush()
-}
-
-fun <K, V> EmbeddedKafkaBroker.opprettKafkaAvroConsumer(groupId: String, topicName: String): Consumer<K, V> {
-
-    val consumerProps = KafkaTestUtils.consumerProps(groupId, "true", this)
-    consumerProps[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = "io.confluent.kafka.serializers.KafkaAvroDeserializer"
-    consumerProps[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] =
-        "io.confluent.kafka.serializers.KafkaAvroDeserializer"
-    consumerProps[KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG] = "true"
-    consumerProps[AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG] = "mock://localhost"
-
-    val consumer = DefaultKafkaConsumerFactory<K, V>(HashMap(consumerProps)).createConsumer()
-    consumer.subscribe(listOf(topicName))
-    return consumer
 }
 
 fun <K, V> EmbeddedKafkaBroker.opprettKafkaStringConsumer(groupId: String, topics: List<String>): Consumer<K, V> {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -9,4 +9,3 @@ kafka:
       auto-offset-reset: earliest
     producer:
       client-id: sif-innsyn-api
-      schema-registry-url: mock://localhost


### PR DESCRIPTION
## Bakgrunn
https://github.com/navikt/k9-dittnav-varsel/pull/251

## Løsning
- Rydder bort AVRO oppsett.
- Fjerner publisering til gammel AVRO topic.

## Andre endringer
- Erstatter enum Ytelse med String. Dette brukes bare for å logge hvilken ytelse man har publisert varsel for. Trenger ikke å være statisk typet.